### PR TITLE
Fix ip package SSRF vulnerability

### DIFF
--- a/js/tests/karma.conf.js
+++ b/js/tests/karma.conf.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('node:path')
-const ip = require('ip')
+const os = require('node:os')
 const { babel } = require('@rollup/plugin-babel')
 const istanbul = require('rollup-plugin-istanbul')
 const { nodeResolve } = require('@rollup/plugin-node-resolve')
@@ -46,6 +46,21 @@ const detectBrowsers = {
 
     throw new Error('Please install Chrome, Chromium or Firefox')
   }
+}
+
+function getLocalExternalAddress() {
+  const networkInterfaces = os.networkInterfaces()
+  for (const addresses of Object.values(networkInterfaces)) {
+    if (!Array.isArray(addresses)) {
+      continue
+    }
+    for (const addressInfo of addresses) {
+      if (addressInfo && addressInfo.family === 'IPv4' && addressInfo.internal === false) {
+        return addressInfo.address
+      }
+    }
+  }
+  return '127.0.0.1'
 }
 
 const config = {
@@ -99,7 +114,7 @@ const config = {
 }
 
 if (BROWSERSTACK) {
-  config.hostname = ip.address()
+  config.hostname = getLocalExternalAddress()
   config.browserStack = {
     username: ENV.BROWSER_STACK_USERNAME,
     accessKey: ENV.BROWSER_STACK_ACCESS_KEY,
@@ -151,7 +166,7 @@ if (BROWSERSTACK) {
   }
 
   if (DEBUG) {
-    config.hostname = ip.address()
+    config.hostname = getLocalExternalAddress()
     plugins.push('karma-jasmine-html-reporter')
     reporters.push('kjhtml')
     config.singleRun = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
         "hammer-simulator": "0.0.1",
         "htmlparser2": "^10.0.0",
         "image-size": "^2.0.2",
-        "ip": "^2.0.1",
         "jasmine": "^5.9.0",
         "jquery": "^3.7.1",
         "js-yaml": "^4.1.0",
@@ -9494,13 +9493,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "hammer-simulator": "0.0.1",
     "htmlparser2": "^10.0.0",
     "image-size": "^2.0.2",
-    "ip": "^2.0.1",
     "jasmine": "^5.9.0",
     "jquery": "^3.7.1",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
### Description

Replaced the `ip` package usage in `js/tests/karma.conf.js` with a custom helper function utilizing Node.js's `os.networkInterfaces` to determine the local external IPv4 address. The `ip` package has also been removed from `package.json` and `package-lock.json`.

### Motivation & Context

This change addresses the SSRF vulnerability (CVE-2023-42282) in the `ip` package (through version 2.0.1). The `ip.isPublic` method was found to improperly categorize certain IP addresses as globally routable, posing a security risk. By removing the `ip` package and replacing its functionality with a native Node.js solution, we eliminate this dependency and mitigate the potential for SSRF.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/twbs/bootstrap/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

- <https://deploy-preview-{your_pr_number}--twbs-bootstrap.netlify.app/>

### Related issues

- CVE-2023-42282

---
<a href="https://cursor.com/background-agent?bcId=bc-0b2a88db-804b-4ed0-939f-223879a26bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b2a88db-804b-4ed0-939f-223879a26bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

